### PR TITLE
Changing executorService.shutdown() to executor.shutdownNow() in all exception blocks to force shutdown of running task.

### DIFF
--- a/src/main/java/org/recap/processor/NyplJobResponsePollingProcessor.java
+++ b/src/main/java/org/recap/processor/NyplJobResponsePollingProcessor.java
@@ -62,25 +62,25 @@ public class NyplJobResponsePollingProcessor {
         } catch (InterruptedException e) {
             logger.error("Nypl job response interrupted for job id -> " + jobId);
             logger.error(ReCAPConstants.REQUEST_EXCEPTION, e);
-            executor.shutdown();
+            executor.shutdownNow();
             jobResponse.setStatusMessage("Nypl job response interrupted : " + e.getMessage());
             return jobResponse;
         } catch (ExecutionException e) {
             logger.error("Nypl job response execution failed for job id -> " + jobId);
             logger.error(ReCAPConstants.REQUEST_EXCEPTION, e);
-            executor.shutdown();
+            executor.shutdownNow();
             jobResponse.setStatusMessage("Nypl job response execution failed : " + e.getMessage());
             return jobResponse;
         } catch (TimeoutException e) {
             logger.error("Nypl job response polling timed out for job id -> " + jobId);
             logger.error(ReCAPConstants.REQUEST_EXCEPTION, e);
-            executor.shutdown();
+            executor.shutdownNow();
             jobResponse.setStatusMessage("Nypl job response polling timed out : " + e.getMessage());
             return jobResponse;
         } catch (Exception e) {
             logger.error("Nypl job response polling failed for job id -> " + jobId);
             logger.error(ReCAPConstants.REQUEST_EXCEPTION, e);
-            executor.shutdown();
+            executor.shutdownNow();
             jobResponse.setStatusMessage("Nypl job response polling failed : " + e.getMessage());
             return jobResponse;
         }


### PR DESCRIPTION
Changing executorService.shutdown() to executor.shutdownNow() in all exception blocks to force shutdown of running task.